### PR TITLE
Fix email link text

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,7 @@ const IndexPage = () => {
               styleName="emailAddress"
               href="mailto:fromkiberawithlove@gmail.com"
             >
-              hello@fromkiberawithlove.com
+              fromkiberawithlove@gmail.com
             </a>
           </p>
         </div>


### PR DESCRIPTION
Why:

Email text was incorrect.

This change addresses the need by:

* Changing email link text